### PR TITLE
Timeline pausing issue

### DIFF
--- a/src/tweenjs/Timeline.js
+++ b/src/tweenjs/Timeline.js
@@ -139,7 +139,7 @@ var p = Timeline.prototype;
 		}
 		if (tweens) { this.addTween.apply(this, tweens); }
 		this.setLabels(labels);
-		if (!props||!props.paused) { Tween._register(this,true); }
+		if (!props||!props.paused) { this.setPaused(false); }
 		if (props&&props.position!=null) { this.setPosition(props.position, Tween.NONE); }
 	}
 	

--- a/src/tweenjs/Tween.js
+++ b/src/tweenjs/Tween.js
@@ -239,7 +239,7 @@ var p = Tween.prototype;
 	 * @type Boolean
 	 * @protected
 	 **/
-	p._paused = false;
+	p._paused = true;
 	
 	/**
 	 * @property _curQueueProps
@@ -327,7 +327,7 @@ var p = Tween.prototype;
 		this._steps = [];
 		this._actions = [];
 		this._catalog = [];
-		if (!props||!props.paused) { Tween._register(this,true); }
+		if (!props||!props.paused) { this.setPaused(false); }
 		if (props&&props.position!=null) { this.setPosition(props.position, Tween.NONE); }
 	}
 	


### PR DESCRIPTION
If Timeline is created with the code below it is impossible to pause it.

```
timeline = new Timeline();
timeline.addTween(tween1);
timeline.addTween(tween2);
timeline.gotoAndPlay(0);

timeline.setPaused(true); //doesn't work
```

This is caused by the timeline being registered in Tween._register() twice, so subsequent unregistering unregisters only one reference from the Tween._tweens array. To prevent this I modified Timeline and Tween constructors to use setPaused() internally. This ensures that _paused flag always indicates if Timeline/Tween is registered with Tween._register().

Let me know what you think.

Cheers,
Iwo Banas
