### PR TITLE
onChange made public

### DIFF
--- a/src/tweenjs/Timeline.js
+++ b/src/tweenjs/Timeline.js
@@ -142,6 +142,7 @@ var p = Timeline.prototype;
 		if (props) {
 			this._useTicks = props.useTicks;
 			this.loop = props.loop;
+			this.onChange = props.onChange;
 			this.ignoreGlobalPause = props.ignoreGlobalPause;
 		}
 		if (tweens) { this.addTween.apply(this, tweens); }


### PR DESCRIPTION
At the moment, onChange function cannot be assigned by a user. This change allows user to send an onChange function, through properties, to listen for the event. Useful for enabling temporary animations where ticker isn't always enabled, or more complicated behaviour when tween isn't enough.
