### PR TITLE
Fixes bug in Timeline.prototype.resolve() validation

### DIFF
--- a/src/tweenjs/Timeline.js
+++ b/src/tweenjs/Timeline.js
@@ -384,7 +384,7 @@ Timeline.prototype.constructor = Timeline;
 	 * @param {String|Number} positionOrLabel A numeric position value or label string.
 	 **/
 	p.resolve = function(positionOrLabel) {
-		var pos = parseFloat(positionOrLabel);
+		var pos = Number(positionOrLabel);
 		if (isNaN(pos)) { pos = this._labels[positionOrLabel]; }
 		return pos;
 	};


### PR DESCRIPTION
resolve() isn't handling frame labels with a leading numeric correctly. If I created a label on frame 10 called "99RedBaloons" and then later do `gotoAndPlay("99RedBaloons");` this function would return 99 as opposed to 10. Casting the contents of `positionOrLabel` using Number() as opposed to parseFloat() will produce more consistent results.

For more on parseFloat vs Number, see https://stackoverflow.com/questions/12227594/which-is-better-numberx-or-parsefloatx
