### PR TITLE
Removed unstubbed function call, replaced with throw.

### DIFF
--- a/src/tweenjs/MotionGuidePlugin.js
+++ b/src/tweenjs/MotionGuidePlugin.js
@@ -286,7 +286,7 @@ this.createjs = this.createjs||{};
 	 * @static
 	 */
 	MotionGuidePlugin.calc = function(data, ratio, target) {
-		if(data._segments == undefined){ MotionGuidePlugin.validate(data); }
+		if(data._segments == undefined){ throw("Missing critical pre-calculated information, please file a bug"); }
 		if(target == undefined){ target = {x:0, y:0, rotation:0}; }
 		var seg = data._segments;
 		var path = data.path;


### PR DESCRIPTION
An unstubbed function call was left in the original draft of the plugin, while the intention is to actually create something that will attempt to resolve the error for now we should throw an error and maybe gather data about how people entered the error scenario.