### PR TITLE
Use javascript functions to parse CSSStyle values and remove regex

### DIFF
--- a/examples/CSSPlugin_square.html
+++ b/examples/CSSPlugin_square.html
@@ -1,0 +1,36 @@
+<html>
+
+<head>
+	<script type="text/javascript" src="../lib/tweenjs-NEXT.js"></script>
+	<script type="text/javascript" src="../src/tweenjs/plugins/CSSPlugin.js"></script>
+</head>
+
+<body>
+</body>
+
+<script>
+    timeMs = 0
+    createjs.Ticker.timingMode = createjs.Ticker.RAF;
+    createjs.Ticker.init();
+    createjs.CSSPlugin.install();
+    var box = document.createElement('div');
+    box.style.setProperty('background-color', '#008800');
+    box.style.setProperty('width', '100px');
+    box.style.setProperty('height', '100px');
+    box.style.setProperty('opacity', '0.4');
+    box.style.setProperty('margin-left', '0');
+    box.style.setProperty('transform', 'skew(30deg, 20deg) scale(0.5, 0.5) rotate(0.2turn)');
+    document.body.appendChild(box);
+
+    createjs.Tween.get(box)
+        .to({ "margin-left": 240, "top": 0 }, 1000, createjs.Ease["sineIn"]) // Move to (300, 200) in 1 second.
+   setTimeout(() => {createjs.Tween.get(box).to({ "opacity": 1.0 }, 1000, createjs.Ease["sineIn"])}, 1000) // Move to (300, 200) in 1 second.
+   setTimeout(() => {createjs.Tween.get(box).to({ "margin-left": 0, "top": 0 }, 1000, createjs.Ease["sineIn"])}, 1000) // Move to (300, 200) in 1 second.
+   setTimeout(() => {createjs.Tween.get(box).to({ "margin-left": 240, "top": 0 }, 1000, createjs.Ease["sineIn"])}, 3000) // Move to (300, 200) in 1 second.
+   setTimeout(() => {createjs.Tween.get(box).to({ "margin-left": 0, "top": 0 }, 1000, createjs.Ease["sineIn"])}, 5000) // Move to (300, 200) in 1 second.
+   setTimeout(() => {createjs.Tween.get(box).to({ "margin-left": 240, "top": 0 }, 1000, createjs.Ease["sineIn"])}, 7000) // Move to (300, 200) in 1 second.
+   setTimeout(() => {createjs.Tween.get(box).to({ "margin-left": 0, "top": 0 }, 1000, createjs.Ease["sineIn"])}, 9000) // Move to (300, 200) in 1 second.
+   setTimeout(() => {createjs.Tween.get(box).to({ "transform": "skew(1deg, 1deg) scale(1, 1) rotate(0turn)" }, 1000, createjs.Ease["sineIn"])}, 1000) // Move to (300, 200) in 1 second.
+</script>
+
+</html>

--- a/src/tweenjs/plugins/CSSPlugin.js
+++ b/src/tweenjs/plugins/CSSPlugin.js
@@ -169,7 +169,11 @@ this.createjs = this.createjs || {};
 			cssData[prop] = "";
 			return initVal;
 		} else {
-			cssData[prop] = result.unit;
+			if (result.unit == 'number')
+				cssData[prop] = '';
+			else
+				cssData[prop] = result.unit;
+
 			return result.value;
 		}
 	};

--- a/src/tweenjs/plugins/CSSPlugin.js
+++ b/src/tweenjs/plugins/CSSPlugin.js
@@ -235,6 +235,7 @@ this.createjs = this.createjs || {};
 				if (compare[1][i].constructor !== result[i].constructor) {
 					console.log("transforms don't match: ", result[0].constructor.name, compare[1][i].constructor.name);
 					compare = null;
+					break;
 				} // component doesn't match
 			}
 		}
@@ -250,36 +251,36 @@ this.createjs = this.createjs || {};
 		if (ratio === 0 || !list1[0]) { return list0[1].toString(); }
 
 		// they match, we want to apply the ratio:
-		let original = list0[1];
-		let modifiedValue = CSSStyleValue.parse("transform", original.toString());
-		let newValue = list1[1];
+		let startValue = list0[1];
+		let newValue = CSSStyleValue.parse("transform", startValue.toString());
+		let endValue = list1[1];
 
 		// Only works for rotate, scale and translate, skew or metrix do not have x,y,z
-		for (let i = 0; i < original.length; i++) {
-			switch (original[i].constructor) {
+		for (let i = 0; i < startValue.length; i++) {
+			switch (startValue[i].constructor) {
 				case CSSRotate:
-					modifiedValue[i].angle.value += (newValue[i].angle.value - original[i].angle.value) * ratio;
+					newValue[i].angle.value += (endValue[i].angle.value - startValue[i].angle.value) * ratio;
 					// Fall down to CSSScale to set x,y,z
 				case CSSTranslate:
 					// Fall down to CSSScale to set x,y,z
 				case CSSScale:
-					modifiedValue[i].x.value += (newValue[i].x.value - original[i].x.value) * ratio;
-					modifiedValue[i].y.value += (newValue[i].y.value - original[i].y.value) * ratio;
-					modifiedValue[i].z.value += (newValue[i].z.value - original[i].z.value) * ratio;
+					newValue[i].x.value += (endValue[i].x.value - startValue[i].x.value) * ratio;
+					newValue[i].y.value += (endValue[i].y.value - startValue[i].y.value) * ratio;
+					newValue[i].z.value += (endValue[i].z.value - startValue[i].z.value) * ratio;
 					break;
 				case CSSSkew:
-					modifiedValue[i].ax.value += (newValue[i].ax.value - original[i].ax.value) * ratio;
-					modifiedValue[i].ay.value += (newValue[i].ay.value - original[i].ay.value) * ratio;
+					newValue[i].ax.value += (endValue[i].ax.value - startValue[i].ax.value) * ratio;
+					newValue[i].ay.value += (endValue[i].ay.value - startValue[i].ay.value) * ratio;
 					break;
 				case CSSSkewX:
-					modifiedValue[i].ax.value += (newValue[i].ax.value - original[i].ax.value) * ratio;
+					newValue[i].ax.value += (endValue[i].ax.value - startValue[i].ax.value) * ratio;
 					break;
 				case CSSSkewY:
-					modifiedValue[i].ay.value += (newValue[i].ay.value - original[i].ay.value) * ratio;
+					newValue[i].ay.value += (endValue[i].ay.value - startValue[i].ay.value) * ratio;
 					break;
 			}
 		}
-		return modifiedValue.toString();
+		return newValue.toString();
 	}
 
 	createjs.CSSPlugin = s;


### PR DESCRIPTION
Added this to prevent failures when values have an exponent. For example: 3.4324e-8 will not be parsed with the current CSSPlugin. To prevent failures for transforms, I've rewritten the parseTransform and writeTransform functions to use CSSStyleValue.parse. 